### PR TITLE
fix: move http_prefix into build block, fix asset link in index.scss

### DIFF
--- a/assets/stylesheets/index.scss
+++ b/assets/stylesheets/index.scss
@@ -5,7 +5,7 @@
 .logo {
   margin-top: $cads-spacing-7;
   display: block;
-  background: url("/source/images/logo.png") no-repeat;
+  background: url("/images/logo.png") no-repeat;
   width: 350px;
   height: 60px;
   background-size: 100%;

--- a/config.rb
+++ b/config.rb
@@ -13,11 +13,15 @@ page '/*.xml', layout: false
 page '/*.json', layout: false
 page '/*.txt', layout: false
 
-config[:http_prefix] = ''
 config[:js_dir] = 'assets/javascripts'
 config[:css_dir] = 'assets/stylesheets'
 set :haml, { :format => :html5 }
 set :markdown_engine, :redcarpet
+
+configure :build do 
+  set :http_prefix, '/intranet'
+  set :relative_links, true
+end
 
 # set :sass_assets_paths, [ 'node_modules', 'node_modules/@citizensadvice/design-system' ]
 # Use webpack to build SCSS so we can use CA design system


### PR DESCRIPTION
So I think this will work:
 - moves the `http_prefix` into the build step, so the built html has a stylesheet link like this:  `<link href="/intranet/assets/stylesheets/index.css" rel="stylesheet" />`
 - fixes the incorrect logo link
 - still serves correctly on `localhost:4567`